### PR TITLE
Fixes generation of UniformMatrix4fv to match expected function signiture

### DIFF
--- a/Source/Library/GLDotNet/GL.Generated.cs
+++ b/Source/Library/GLDotNet/GL.Generated.cs
@@ -2446,7 +2446,7 @@ namespace GLDotNet
 
 			public delegate void UniformMatrix4dv(int location, int count, bool transpose, double[] value);
 
-			public delegate void UniformMatrix4fv(int location, int count, bool transpose, ref float value);
+			public delegate void UniformMatrix4fv(int location, int count, bool transpose, float[] value);
 
 			public delegate void UniformMatrix4x2dv(int location, int count, bool transpose, double[] value);
 
@@ -11448,9 +11448,9 @@ namespace GLDotNet
 #endif
 		}
 
-		public void UniformMatrix4fv(int location, int count, bool transpose, ref float value)
+		public void UniformMatrix4fv(int location, int count, bool transpose, float[] value)
 		{
-			this._UniformMatrix4fv(location, count, transpose, ref value);
+			this._UniformMatrix4fv(location, count, transpose, value);
 #if DEBUG
 			this.CheckErrors("UniformMatrix4fv");
 #endif

--- a/Source/Library/GLDotNet/GL.Generated.cs
+++ b/Source/Library/GLDotNet/GL.Generated.cs
@@ -2448,6 +2448,8 @@ namespace GLDotNet
 
 			public delegate void UniformMatrix4fv(int location, int count, bool transpose, float[] value);
 
+			public delegate void UniformMatrix4fvByRef(int location, int count, bool transpose, ref float value);
+
 			public delegate void UniformMatrix4x2dv(int location, int count, bool transpose, double[] value);
 
 			public delegate void UniformMatrix4x2fv(int location, int count, bool transpose, float[] value);
@@ -3758,6 +3760,8 @@ namespace GLDotNet
 
 		private Delegates.UniformMatrix4fv _UniformMatrix4fv;
 
+		private Delegates.UniformMatrix4fvByRef _UniformMatrix4fvByRef;
+
 		private Delegates.UniformMatrix4x2dv _UniformMatrix4x2dv;
 
 		private Delegates.UniformMatrix4x2fv _UniformMatrix4x2fv;
@@ -4695,6 +4699,11 @@ namespace GLDotNet
 				this._GetnUniformuiv = (Delegates.GetnUniformuiv)Marshal.GetDelegateForFunctionPointer(this.platformContext.GetProcAddress("glGetnUniformuiv"), typeof(Delegates.GetnUniformuiv));
 				this._ReadnPixels = (Delegates.ReadnPixels)Marshal.GetDelegateForFunctionPointer(this.platformContext.GetProcAddress("glReadnPixels"), typeof(Delegates.ReadnPixels));
 				this._TextureBarrier = (Delegates.TextureBarrier)Marshal.GetDelegateForFunctionPointer(this.platformContext.GetProcAddress("glTextureBarrier"), typeof(Delegates.TextureBarrier));
+			}
+
+			if (this.platformContext.VersionMajor > 0 || (this.platformContext.VersionMajor == 0 && this.platformContext.VersionMinor >= 0))
+			{
+				this._UniformMatrix4fvByRef = (Delegates.UniformMatrix4fvByRef)Marshal.GetDelegateForFunctionPointer(this.platformContext.GetProcAddress("glUniformMatrix4fv"), typeof(Delegates.UniformMatrix4fvByRef));
 			}
 
 			this.Initialize();
@@ -11453,6 +11462,14 @@ namespace GLDotNet
 			this._UniformMatrix4fv(location, count, transpose, value);
 #if DEBUG
 			this.CheckErrors("UniformMatrix4fv");
+#endif
+		}
+
+		public void UniformMatrix4fvByRef(int location, int count, bool transpose, ref float value)
+		{
+			this._UniformMatrix4fvByRef(location, count, transpose, ref value);
+#if DEBUG
+			this.CheckErrors("UniformMatrix4fvByRef");
 #endif
 		}
 

--- a/Source/Tools/Generator/Program.cs
+++ b/Source/Tools/Generator/Program.cs
@@ -117,9 +117,6 @@ namespace GLGenerator
             glGetShaderInfoLog.Params.Single(x => x.Name == "length").OverrideType("out int");
             glGetShaderInfoLog.OutputPublicMethod = false;
 
-            var glUniformMatrix4fv = functions.Single(x => x.Name == "glUniformMatrix4fv");
-            glUniformMatrix4fv.Params.Single(x => x.Name == "value").OverrideType("float", "ref");
-
             // The following overrides can be reenabled once out parameters are properly implemented.
             functions.Single(x => x.Name == "glGetActiveAttrib").DisableEnumGroupOverload = true;
             functions.Single(x => x.Name == "glGetActiveUniform").DisableEnumGroupOverload = true;


### PR DESCRIPTION
When passing a 4x4 matrix to a shader through a uniform, "glUniformMatrix4fv" expects a "float[]" as input. However, the current implementation of "GL.UniformMatrix4fv" overrides this and expects a reference to a "float". This makes the function unusable as far as I could tell (and is different from the implementations of  other "uniform" functions in this library).

In the "Generator" project, there is an override for "glUniformMatrix4fv" to change the value to "ref float". Removing these two lines allows the generator to generate the expected function parameters.